### PR TITLE
Fix wp is not a registered wp command error when running vip datasync

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -32,5 +32,5 @@ function setup() {
  * Scrub data on WP VIP data sync
  */
 function vip_scrub_data() {
-	\WP_CLI::runCommand( apply_filters( 'wp_scrubber_vip_cleanup_command', 'wp scrub all' ) );
+	\WP_CLI::runCommand( apply_filters( 'wp_scrubber_vip_cleanup_command', 'scrub all' ) );
 }


### PR DESCRIPTION
### Description of the Change
This PR fixes an error that occurs when running a VIP datasync.

Currently when running the command with this plugin active you get an error that stops the CLLI command continuing to other actions.

`# wp vip data-cleanup datasync
Error: 'wp' is not a registered wp command. See 'wp help' for available commands.
Did you mean 'amp'? `

This is caused by the inclusion of `wp` itself in the call to `WP_CLI::run_command()`

### How to test the Change
With the plugin active in a VIP non-production or DEV-ENV environment try running the `wp vip data-cleanup datasync` command.

Make sure you no longer see the following error;

`# wp vip data-cleanup datasync
Error: 'wp' is not a registered wp command. See 'wp help' for available commands.
Did you mean 'amp'? `

After the change it should carry on with the scrub

```
wp vip data-cleanup datasync

Scrubbing users...
 - Duplicating users table into temp tables...
 - Scrubbing each user record...
 - Duplicating user meta table into temp table...
 - Replacing user tables with the scrubbed versions...
Scrubbing comments on wp_comments...
 - Duplicating comments table into temp table...
 - Duplicating comment meta table into temp table...
 - Scrubbing comments table...
 - Replacing comment tables with the scrubbed versions...
Success: Datasync cleanup completed.
```


### Changelog Entry
Fixed - Bug fix


### Credits
@anigeluk 


### Checklist:
- [ x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
