### PR TITLE
Add a `wp plugin install` snippet for convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 ## Installation
 
 1. Clone or download the plugin files into your WordPress plugins directory.
+   ```
+   wp plugin install https://github.com/10up/wp-scrubber/archive/refs/heads/develop.zip --activate
+   ```
    1. Note: If on WordPress VIP, the plugin should be added to the `/client-mu-plugins` directory.
 2. Activate the plugin through the WordPress admin interface or via WP-CLI.
 3. Set the `WP_ENVIRONMENT_TYPE` to `local` or `staging`.


### PR DESCRIPTION
This allows users to click the "copy to clipboard" icon, then paste it into a terminal. That saves time over manually finding the URL from the GitHub interface and then typing out the command.

### Changelog Entry

> Developer - Added install command to README for convienence.

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [N/A] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [N/A] All new and existing tests pass.
