### PR TITLE
Update README.md: wp-scrubber.json location and meta_fields format

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ WP Scrubber scrubs PII based on where WordPress core stores data (users, comment
 
 ## JSON Configuration
 WP Scrubber also includes the option to configure scrubbing rules using a JSON configuration file. This allows for more detailed and flexible scrubbing rules for post types, taxonomies, options, user data, custom tables, and truncating tables.
-To use the JSON configuration, create a `wp-scrubber.json` file in the root of your WordPress installation. The plugin will automatically detect and use this file for scrubbing rules.
+To use the JSON configuration, create a `wp-scrubber.json` file in the `wp-content` directory of your WordPress installation. The plugin will automatically detect and use this file for scrubbing rules.
 
 ### JSON Configuration Structure
 
@@ -120,7 +120,7 @@ Define which post types and their associated fields and meta fields to scrub.
         // More fields...
       ],
       "meta_fields": [
-        { "key": "meta_key_name", "action": "replace", "value": "new value" }
+        { "name": "meta_key_name", "action": "replace", "value": "new value" }
         // More meta_fields...
       ]
     },
@@ -136,7 +136,7 @@ Define which post types and their associated fields and meta fields to scrub.
 	- `faker_type`: Type of fake data from Faker (e.g., `sentence`).
 	- `value`: Replacement value for `replace` action.
 - `meta_fields`: Post meta fields to scrub.
-	- `key`: Meta key.
+	- `name`: Meta key.
 	- `action`, `faker_type`, `value`: As described above.
 
 #### Taxonomies
@@ -152,7 +152,7 @@ Define taxonomies and their terms and meta fields to scrub.
         // More fields...
       ],
       "meta_fields": [
-        { "key": "meta_key_name", "action": "replace", "value": "new value" }
+        { "name": "meta_key_name", "action": "replace", "value": "new value" }
         // More meta_fields...
       ]
     },
@@ -165,7 +165,7 @@ Define taxonomies and their terms and meta fields to scrub.
 - `fields`: Fields to scrub within the terms.
 	- `name`, `action`, `faker_type`, `value`: As described above.
 - `meta_fields`: Term meta fields to scrub.
-	- `key`, `action`, `faker_type`, `value`: As described above.
+	- `name`, `action`, `faker_type`, `value`: As described above.
 
 #### Options
 Define WordPress options to scrub.
@@ -193,7 +193,7 @@ Define user data fields to scrub.
       // More user_data...
     ],
     "meta_fields": [
-      { "key": "meta_key_name", "action": "replace", "value": "new value" }
+      { "name": "meta_key_name", "action": "replace", "value": "new value" }
       // More meta_fields...
     ]
   ]
@@ -203,7 +203,7 @@ Define user data fields to scrub.
 - `fields`: Fields to scrub within the user.
 	- `name`, `action`, `faker_type`, `value`: As described above.
 - `meta_fields`: User meta fields to scrub.
-	- `key`, `action`, `faker_type`, `value`: As described above.
+	- `name`, `action`, `faker_type`, `value`: As described above.
 
 #### Custom Tables
 Define custom tables and columns to scrub.


### PR DESCRIPTION
### Description of the Change
This update modifies the JSON configuration documentation within the `README.md` file. It changes the file location reference for `wp-scrubber.json` to the `wp-content` directory. The `meta_fields` documentation has also been updated, replacing `key` with `name` to match the expected structure and align with the `config-example.json` file.

### Changelog Entry
> Changed – Updated `README.md` to reflect expected location for `wp-scrubber.json` and corrected `meta_fields` format to use `name` instead of `key`.

### Credits
Props @mustardBees

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [n/a] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [n/a] All new and existing tests pass.
